### PR TITLE
mendel issues

### DIFF
--- a/examples/full-example/isomorphic/base/main.js
+++ b/examples/full-example/isomorphic/base/main.js
@@ -4,6 +4,7 @@
 import App from './components/app';
 import React from 'react'; // eslint-disable-line
 import '../../config.json';
+import Twemoji from 'twemoji';
 
 if (typeof document !== 'undefined') {
     const ReactDOM = require('react-dom');

--- a/examples/full-example/package.json
+++ b/examples/full-example/package.json
@@ -17,7 +17,8 @@
     "mendel-middleware": "*",
     "morgan": "^1.7.0",
     "react": "^15.4.2",
-    "react-dom": "^15.4.2"
+    "react-dom": "^15.4.2",
+    "twemoji": "^2.2.5"
   },
   "devDependencies": {
     "autoprefixer": "^6.7.6",


### PR DESCRIPTION
Twemoji uses global https://github.com/twitter/twemoji/blob/gh-pages/2/twemoji.npm.js#L1

and so once we add this pkg we get error on console

Uncaught ReferenceError: global is not defined
    at Object.require../node_modules/twemoji/2/twemoji.npm.js ((index):1)
    at s (_prelude.js:1)
    at s (main:1)
    at main:1
    at Object.require.0.../../config.json (main:14)
    at s (main:1)
    at e (main:1)
    at main:1

and the app becomes unusable.